### PR TITLE
fix: correct inverted off-peak window check in async_check_offpeak

### DIFF
--- a/myelectricaldatapy/myelectricaldata.py
+++ b/myelectricaldatapy/myelectricaldata.py
@@ -28,7 +28,6 @@ class Enedis:
         self.auth = EnedisAuth(session, token, timeout)
         self.async_request = self.auth.async_request
         self.offpeaks: list[str] = []
-        self.dt_offpeak: list[dt] = []
         self.last_access: date | None = None
 
     async def async_fetch_datas(
@@ -69,13 +68,6 @@ class Enedis:
                 contract = usage_point.get("contracts", {})
                 if offpeak_hours := contract.get("offpeak_hours"):
                     self.offpeaks = re.findall("(?:(\\w+)-(\\w+))+", offpeak_hours)
-                    self.dt_offpeak = [
-                        (  # type: ignore
-                            dt.strptime(offpeak[0], "%HH%M"),
-                            dt.strptime(offpeak[1], "%HH%M"),
-                        )
-                        for offpeak in self.offpeaks
-                    ]
         return contract
 
     async def async_get_contracts(self, pdl: str) -> Any:
@@ -137,7 +129,7 @@ class Enedis:
             for range_time in self.offpeaks:
                 starting = dt.strptime(range_time[0], "%HH%M").time()
                 ending = dt.strptime(range_time[1], "%HH%M").time()
-                if ending <= start_time > starting:
+                if starting < start_time <= ending:
                     return True
         return False
 

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -54,6 +54,34 @@ async def test_tempoday(mock_enedis: Mock) -> None:  # pylint: disable=unused-ar
     assert mypdl.tempo_day == "blue"
 
 
+@freeze_time("2023-03-01")
+async def test_check_offpeak(mock_contract) -> None:
+    """Test off-peak hour detection against the real contract's schedule.
+
+    contract.json's offpeak_hours is "HC (1H30-8H00;12H30-14H00)". Patches
+    the HTTP layer (not async_get_contract itself) so the real parsing in
+    Enedis.async_get_contract runs and populates self.offpeaks.
+    """
+    with patch.object(
+        myelectricaldatapy.auth.EnedisAuth,
+        "async_request",
+        return_value=mock_contract,
+    ):
+        api = Enedis(token=TOKEN, session=ClientSession())
+        assert await api.async_has_offpeak(PDL) is True
+
+        # 03:00 falls inside the 01:30-08:00 off-peak window
+        assert await api.async_check_offpeak(PDL, dt(2023, 3, 1, 3, 0)) is True
+        # exactly on the lower bound is excluded (start, end] convention
+        assert await api.async_check_offpeak(PDL, dt(2023, 3, 1, 1, 30)) is False
+        # exactly on the upper bound is included
+        assert await api.async_check_offpeak(PDL, dt(2023, 3, 1, 8, 0)) is True
+        # standard hours, not off-peak
+        assert await api.async_check_offpeak(PDL, dt(2023, 3, 1, 10, 0)) is False
+        # second window 12:30-14:00
+        assert await api.async_check_offpeak(PDL, dt(2023, 3, 1, 13, 0)) is True
+
+
 async def test_valid_access(mock_enedis: Mock) -> None:  # pylint: disable=unused-argument
     """Test access."""
     api = Enedis(token=TOKEN, session=ClientSession())


### PR DESCRIPTION
## Summary
Follow-up to #155 (already merged) — this is the third bug found while auditing the analytics calculations, discovered after #155 was already merged, so it needs its own PR.

`Enedis.async_check_offpeak` (`myelectricaldata.py`) used the chained comparison:
```python
if ending <= start_time > starting:
    return True
```
In Python this evaluates as `(ending <= start_time) and (start_time > starting)` — not "is `start_time` within the off-peak window". For the real off-peak schedule in `tests/fixtures/contract.json` (`"HC (1H30-8H00;12H30-14H00)"`), this returned:
- `False` at 03:00 — which **is** inside the 01:30-08:00 off-peak window
- `True` at 10:00 and 23:00 — which are **not** off-peak

i.e. inverted for any time outside the window itself. No test covered this method, which is how it went unnoticed.

Fixed to `starting < start_time <= ending`, consistent with the `(start, end]` convention already used by `analytics.py::_get_data_interval`. Added `test_check_offpeak`, built directly from `contract.json`'s real `offpeak_hours` string — verified it fails on the old comparison and passes with the fix.

Also dropped `self.dt_offpeak`: computed in `async_get_contract` but never read anywhere in the codebase.

## Test plan
- [x] `pytest tests/` — 20/20 passed
- [x] Verified `test_check_offpeak` fails against the old (reverted) comparison and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)