### PR TITLE
fix: only auto-merge PRs actually opened by dependabot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependency:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && (github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]') }}
     steps:
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
## Summary
PR #158 (a human-authored PR, not a dependency bump) got auto-approved and auto-merged unexpectedly right after it was opened.

Root cause: `.github/workflows/auto-approve.yml`'s condition checks `github.actor`, which is whoever triggered the `pull_request` event — not who opened the PR. This repo has the **pre-commit.ci** GitHub App installed, which pushes an auto-fix commit to *any* PR when pre-commit hooks change something. That push generates a `synchronize` event with `github.actor == 'pre-commit-ci[bot]'`, which matched this workflow's `if:` condition (originally meant only for Dependabot PRs) and triggered `gh pr review --approve` + `gh pr merge --auto --merge` on PR #158.

## Fix
Add `github.event.pull_request.user.login == 'dependabot[bot]'` to the condition, so the workflow only ever acts on PRs that were actually opened by Dependabot — regardless of which bot's commit triggered the specific event. pre-commit.ci's fix-up commits on a genuine Dependabot PR will still keep the auto-merge working, since the PR author check passes independently of the triggering actor.

## Test plan
- [x] Read through the updated condition logic; a non-Dependabot PR that receives a pre-commit.ci fix-up commit will no longer satisfy `github.event.pull_request.user.login == 'dependabot[bot]'`
- [ ] Next Dependabot PR should still auto-merge as before (can't be tested until one opens)
